### PR TITLE
triton-kubernetes#161  The -module option is no longer supported since Terraform 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/.vscode
 bin/terraform*
 */terraform.tfstate*
 terraform/.terraform*

--- a/create/cluster.go
+++ b/create/cluster.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultSourceURL = "github.com/joyent/triton-kubernetes"
+	defaultSourceURL = "gitlab.com/hydrahost-developers/kubernetes-triton"
 	defaultSourceRef = "master"
 )
 

--- a/create/cluster.go
+++ b/create/cluster.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultSourceURL = "gitlab.com/hydrahost-developers/kubernetes-triton"
+	defaultSourceURL = "github.com/joyent/triton-kubernetes"
 	defaultSourceRef = "master"
 )
 

--- a/create/manager_triton.go
+++ b/create/manager_triton.go
@@ -42,6 +42,10 @@ type tritonManagerTerraformConfig struct {
 	MasterTritonMachinePackage string   `json:"master_triton_machine_package,omitempty"`
 }
 
+type typeManagerOutput struct {
+	Value string `json:"value"`
+}
+
 func newTritonManager(currentState state.State, name string) error {
 	nonInteractiveMode := viper.GetBool("non-interactive")
 
@@ -52,6 +56,18 @@ func newTritonManager(currentState state.State, name string) error {
 
 	cfg := tritonManagerTerraformConfig{
 		baseManagerTerraformConfig: baseConfig,
+	}
+
+	rancherAccessKeyOtpt := typeManagerOutput{
+		Value: "${module.cluster-manager.rancher_access_key}",
+	}
+
+	rancherSecretKeyOtpt := typeManagerOutput{
+		Value: "${module.cluster-manager.rancher_secret_key}",
+	}
+
+	rancherUrlKeyOtpt := typeManagerOutput{
+		Value: "${module.cluster-manager.rancher_url}",
 	}
 
 	// Triton Account
@@ -394,6 +410,9 @@ func newTritonManager(currentState state.State, name string) error {
 	}
 
 	currentState.SetManager(&cfg)
+	currentState.SetOutput(&rancherUrlKeyOtpt, "rancher_url")
+	currentState.SetOutput(&rancherAccessKeyOtpt, "rancher_access_key")
+	currentState.SetOutput(&rancherSecretKeyOtpt, "rancher_secret_key")
 
 	return nil
 }

--- a/shell/run_terraform.go
+++ b/shell/run_terraform.go
@@ -140,7 +140,7 @@ func RunTerraformDestroyWithState(currentState state.State, args []string) error
 	}
 
 	// Run terraform destroy
-	allArgs := append([]string{"destroy", "-force"}, args...)
+	allArgs := append([]string{"destroy", "-auto-approve"}, args...)
 	err = runShellCommand(&shellOptions, "terraform", allArgs...)
 	if err != nil {
 		return err

--- a/shell/run_terraform.go
+++ b/shell/run_terraform.go
@@ -182,7 +182,7 @@ func RunTerraformOutputWithState(state state.State, moduleName string) error {
 	}
 
 	// Run terraform output
-	err = runShellCommand(&shellOptions, "terraform", "output", "-module", moduleName)
+	err = runShellCommand(&shellOptions, "terraform", "output")
 	if err != nil {
 		return err
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/Jeffail/gabs"
@@ -38,6 +39,16 @@ func (state *State) SetManager(obj interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+func (state *State) SetOutput(obj interface{}, outputName string) error {
+	_, err := state.configJSON.SetP(obj, fmt.Sprintf("output.%s", outputName))
+	if err != nil {
+		return err
+	}
+	ioutil.WriteFile("/tmp/main.tf.json", state.configJSON.Bytes(), 0777)
 
 	return nil
 }

--- a/state/state.go
+++ b/state/state.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	"github.com/Jeffail/gabs"
@@ -48,7 +47,6 @@ func (state *State) SetOutput(obj interface{}, outputName string) error {
 	if err != nil {
 		return err
 	}
-	ioutil.WriteFile("/tmp/main.tf.json", state.configJSON.Bytes(), 0777)
 
 	return nil
 }

--- a/terraform/modules/bare-metal-rancher-k8s-host/main.tf
+++ b/terraform/modules/bare-metal-rancher-k8s-host/main.tf
@@ -32,10 +32,9 @@ resource "null_resource" "install_rancher_agent" {
   }
 
   provisioner "remote-exec" {
-    inline = <<EOF
-      ${data.template_file.install_rancher_agent.rendered}
-      
-EOF
+    inline = [
+      "${data.template_file.install_rancher_agent.rendered}"
+    ]
 
   }
 }

--- a/terraform/modules/bare-metal-rancher/main.tf
+++ b/terraform/modules/bare-metal-rancher/main.tf
@@ -31,11 +31,9 @@ resource "null_resource" "install_docker" {
   }
 
   provisioner "remote-exec" {
-    inline = <<EOF
-      ${data.template_file.install_docker.rendered}
-      
-EOF
-
+    inline = [
+      "${data.template_file.install_docker.rendered}"
+    ]
   }
 }
 
@@ -66,11 +64,9 @@ resource "null_resource" "install_rancher_master" {
   }
 
   provisioner "remote-exec" {
-    inline = <<EOF
-      ${data.template_file.install_rancher_master.rendered}
-      
-EOF
-
+    inline = [
+      "${data.template_file.install_rancher_master.rendered}"
+    ]
   }
 }
 
@@ -101,10 +97,9 @@ resource "null_resource" "setup_rancher_k8s" {
   }
 
   provisioner "remote-exec" {
-    inline = <<EOF
-      ${data.template_file.setup_rancher_k8s.rendered}
-      
-EOF
+    inline = [
+      "${data.template_file.setup_rancher_k8s.rendered}"
+      ]
 
   }
 }


### PR DESCRIPTION
This change fixes the issue on terraform output for triton-kubernetes implementation on Triton's platform.