### PR TITLE
Fix terraform outputs

### DIFF
--- a/create/manager_triton.go
+++ b/create/manager_triton.go
@@ -42,6 +42,10 @@ type tritonManagerTerraformConfig struct {
 	MasterTritonMachinePackage string   `json:"master_triton_machine_package,omitempty"`
 }
 
+type typeManagerOutput struct {
+	Value string `json:"value"`
+}
+
 func newTritonManager(currentState state.State, name string) error {
 	nonInteractiveMode := viper.GetBool("non-interactive")
 
@@ -52,6 +56,18 @@ func newTritonManager(currentState state.State, name string) error {
 
 	cfg := tritonManagerTerraformConfig{
 		baseManagerTerraformConfig: baseConfig,
+	}
+
+	rancherAccessKeyOtpt := typeManagerOutput{
+		Value: "${module.cluster-manager.rancher_access_key}",
+	}
+
+	rancherSecretKeyOtpt := typeManagerOutput{
+		Value: "${module.cluster-manager.rancher_secret_key}",
+	}
+
+	rancherUrlKeyOtpt := typeManagerOutput{
+		Value: "${module.cluster-manager.rancher_url}",
 	}
 
 	// Triton Account
@@ -394,6 +410,9 @@ func newTritonManager(currentState state.State, name string) error {
 	}
 
 	currentState.SetManager(&cfg)
+	currentState.SetOutput(&rancherUrlKeyOtpt, "rancher_url")
+	currentState.SetOutput(&rancherAccessKeyOtpt, "rancher_access_key")
+	currentState.SetOutput(&rancherSecretKeyOtpt, "rancher_secret_key")
 
 	return nil
 }

--- a/shell/run_terraform.go
+++ b/shell/run_terraform.go
@@ -182,7 +182,7 @@ func RunTerraformOutputWithState(state state.State, moduleName string) error {
 	}
 
 	// Run terraform output
-	err = runShellCommand(&shellOptions, "terraform", "output", "-module", moduleName)
+	err = runShellCommand(&shellOptions, "terraform", "output")
 	if err != nil {
 		return err
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/Jeffail/gabs"
@@ -38,6 +39,16 @@ func (state *State) SetManager(obj interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+func (state *State) SetOutput(obj interface{}, outputName string) error {
+	_, err := state.configJSON.SetP(obj, fmt.Sprintf("output.%s", outputName))
+	if err != nil {
+		return err
+	}
+	ioutil.WriteFile("/tmp/main.tf.json", state.configJSON.Bytes(), 0777)
 
 	return nil
 }

--- a/state/state.go
+++ b/state/state.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	"github.com/Jeffail/gabs"
@@ -48,7 +47,6 @@ func (state *State) SetOutput(obj interface{}, outputName string) error {
 	if err != nil {
 		return err
 	}
-	ioutil.WriteFile("/tmp/main.tf.json", state.configJSON.Bytes(), 0777)
 
 	return nil
 }


### PR DESCRIPTION
This pull request fixes an issue thread that is first described on #161.

Issue:
terraform -module option:
 In order to get the authentication values returned by rancher, triton-kubernetes uses the old terraform output -module <module_name> option. Terraform has deprecated this option and is no longer saving modules output on it's tfstate.
 In order to save the outputs back on the tfstate file I had to move it to the terraform module implementation, this way when terraform output is executed it returns all rancher outputs that are required by triton-kubernetes create cluster.
 