### PR TITLE
Replaced deprecated destroy flag

### DIFF
--- a/shell/run_terraform.go
+++ b/shell/run_terraform.go
@@ -140,7 +140,7 @@ func RunTerraformDestroyWithState(currentState state.State, args []string) error
 	}
 
 	// Run terraform destroy
-	allArgs := append([]string{"destroy", "-force"}, args...)
+	allArgs := append([]string{"destroy", "-auto-approve"}, args...)
 	err = runShellCommand(&shellOptions, "terraform", allArgs...)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes Terraform compatibility for **>=0.15**
From 0.11.4 and up, this flag was deprecated and removed in 0.15 release
Reference:
- https://github.com/hashicorp/terraform/issues/17218 - Deprecation note
- https://github.com/hashicorp/terraform/pull/27681 - Removal of the flag